### PR TITLE
Make log4j an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
             <scope>runtime</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
...as it is in the main elasticsearch pom.xml. This is useful for people who want to use slf4j/logback instead of log4j.
