### PR TITLE
Add support for CommonJS with Rhino

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,16 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>${project.basedir}/src/test/resources/</directory>
+                <targetPath>${project.build.testOutputDirectory}</targetPath>
+            </testResource>
+        	<testResource>
+        		<directory>${project.basedir}/src/test/resources/scripts</directory>
+                <targetPath>${project.build.testOutputDirectory}/conf/scripts</targetPath>
+        	</testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTest.java
+++ b/src/test/java/org/elasticsearch/script/javascript/JavaScriptScriptMultiThreadedTest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.script.javascript;
 
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.util.concurrent.jsr166y.ThreadLocalRandom;
+import org.elasticsearch.env.Environment;
 import org.elasticsearch.script.ExecutableScript;
 import org.elasticsearch.test.ElasticsearchTestCase;
 import org.junit.Test;
@@ -40,7 +41,8 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
 
     @Test
     public void testExecutableNoRuntimeParams() throws Exception {
-        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(
+                ImmutableSettings.Builder.EMPTY_SETTINGS, new Environment());
         final Object compiled = se.compile("x + y");
         final AtomicBoolean failed = new AtomicBoolean();
 
@@ -84,7 +86,10 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
 
     @Test
     public void testExecutableWithRuntimeParams() throws Exception {
-        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(
+                ImmutableSettings.Builder.EMPTY_SETTINGS, new Environment(
+                ImmutableSettings.settingsBuilder()
+                        .put("path.conf", "target/conf").build()));
         final Object compiled = se.compile("x + y");
         final AtomicBoolean failed = new AtomicBoolean();
 
@@ -127,7 +132,10 @@ public class JavaScriptScriptMultiThreadedTest extends ElasticsearchTestCase {
 
     @Test
     public void testExecute() throws Exception {
-        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(ImmutableSettings.Builder.EMPTY_SETTINGS);
+        final JavaScriptScriptEngineService se = new JavaScriptScriptEngineService(
+                ImmutableSettings.Builder.EMPTY_SETTINGS, new Environment(
+                ImmutableSettings.settingsBuilder()
+                        .put("path.conf", "target/conf").build()));
         final Object compiled = se.compile("x + y");
         final AtomicBoolean failed = new AtomicBoolean();
 

--- a/src/test/resources/scripts/modules/pi.js
+++ b/src/test/resources/scripts/modules/pi.js
@@ -1,0 +1,4 @@
+// export function
+exports.getPI = function(value) {
+    return 3.14;
+};

--- a/src/test/resources/scripts/test1.js
+++ b/src/test/resources/scripts/test1.js
@@ -1,0 +1,2 @@
+var pi = require('pi');
+ctx.pi = pi.getPI();


### PR DESCRIPTION
You can add your javascript modules under `config/scripts/modules/` and use them
in scripts:

For example, add `config/scripts/modules/pi.js`

``` javascript
exports.getPI = function(value) {
    return 3.14;
};
```

You can use it in a script:

``` javascript
var pi = require('pi');
ctx.pi = pi.getPI();
```

Closes #6.
Closes #7.
